### PR TITLE
Ruleset update to prevent certain bedrock bypasses

### DIFF
--- a/index.md
+++ b/index.md
@@ -34,7 +34,9 @@ No player shall, during any official match he or she participates in, beginning 
 7. Impede any other player from entering her or his lane<sup>[2]</sup> from the starting platform.
 8. Break any block on, or take any block or item from the starting platform.
 9. Logout/login as a means to gain any advantage, including avoiding PvP or other hazards. Logging out and in to address lag or fix chunk errors is permissible.
-10. Throw any ender pearl, or enter any rideable entity or bed, while occupying any position partially outside of his or her lane.
+10. Throw any ender pearl, or enter any rideable entity or bed, while:
+    1. the player is occupying any position partially outside of his or her lane, or
+    2. in the case of a rideable entity, the location clicked is partially outside of the player's lane.
 11. Cause or allow any part of his or her character’s collision box to occupy the same area as any bedrock block for any period of time. 
 12. Cause any entity to occupy the same location as any block for the purpose of forcing that entity to travel:
     1. through any unbreakable block<sup>[3]</sup>, or

--- a/index.md
+++ b/index.md
@@ -41,7 +41,9 @@ No player shall, during any official match he or she participates in, beginning 
 12. Cause any entity to occupy the same location as any block for the purpose of forcing that entity to travel:
     1. through any unbreakable block<sup>[3]</sup>, or
     2. upwards through multiple blocks
-13. Make use of the game's bed exiting or respawning mechanics, or rideable entity exiting mechanics, to teleport a player or entity across a barrier composed of unbreakable blocks<sup>[3]</sup>.
+13. Teleport a player or entity across a barrier composed of unbreakable blocks<sup>[3]</sup>, by making use of either:
+    1. the bed exiting or respawning mechanics, or
+    2. the rideable entity entry or exiting mechanics, except where the destination the player will teleport to is in their direct line of sight, unimpeded by any non-air blocks.
 14. Cause any unbreakable block<sup>[3]</sup> to be removed or replaced with any other block.
 15. Use any Minecraft client that been modified in any way, apart from having one or more of the following mods installed. Additional mods may be added to this list in response to player requests:
     1. [Optifine](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/1272953-optifine-hd-a4-fps-boost-hd-textures-aa-af-and)

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-version: 2.3.1
+version: 2.3.2
 ---
 
 # Section I: Precedence of Rules
@@ -34,7 +34,7 @@ No player shall, during any official match he or she participates in, beginning 
 7. Impede any other player from entering her or his lane<sup>[2]</sup> from the starting platform.
 8. Break any block on, or take any block or item from the starting platform.
 9. Logout/login as a means to gain any advantage, including avoiding PvP or other hazards. Logging out and in to address lag or fix chunk errors is permissible.
-10. Throw any ender pearl, or enter any minecart, boat, or bed, while occupying any position partially outside of his or her lane.
+10. Throw any ender pearl, or enter any rideable entity or bed, while occupying any position partially outside of his or her lane.
 11. Cause or allow any part of his or her character’s collision box to occupy the same area as any bedrock block for any period of time. 
 12. Cause any entity to occupy the same location as any block for the purpose of forcing that entity to travel:
     1. through any unbreakable block<sup>[3]</sup>, or


### PR DESCRIPTION
The rule previously would have permitted the use of horses or saddled pigs as a way of bypassing bedrock on a lane edge. This change makes this illegal.
